### PR TITLE
tips: remove CartInstall in favour of GodMode9 native function

### DIFF
--- a/tips.html
+++ b/tips.html
@@ -45,10 +45,9 @@
 					<li>For splashes: enable splash settings in Luma3DS Config (hold SELECT during boot).</li>
 					<li>To make a custom splash check out <a href="https://xem.github.io/3DShomebrew/tools/image-to-bin.html" target="_blank">this splash generator!</a></li>
 				</ol></li>
-			<li>Dump your physical games to digital copies.
+			<li>Dump your physical games to digital copies with <a href="https://3ds.hacks.guide/dumping-titles-and-game-cartridges">GodMode9.</a>
 				<ol>
-          <li>Try <a href="https://github.com/knight-ryu12/godmode9-layeredfs-usage/wiki/CartInstall-guide">CartInstall</a> to directly install cartridges to your 3DS.</li>
-					<li>If you need the game ROM itself, check <a href="https://3ds.hacks.guide/dumping-titles-and-game-cartridges" target="_blank">here</a> for instructions on how to dump games, updates, and DLC.</li>
+					<li>GodMode9 can dump game ROM itself, as well as install your physical game directly to the SD card. You can even dump game updates, and DLC.</li>
 					<li>For CIAs dumped from cartridges: install the CIA with FBI. It will appear on your home menu. <b>Note:</b> You must have enough space on your SD card to MAKE the CIA as well as INSTALL it. That means having twice the space the game takes available on your SD when you install it. After the game is installed, the CIA will be useless, and can be deleted with no issue.
 					<br>For NDS games dumped to .nds files: install <a href="https://wiki.ds-homebrew.com/twilightmenu/installing-3ds" target="_blank">TWiLightMenu++</a> and use it to play NDS dumps.
 					<br>The other options on that page are for more specific circumstances.</li>


### PR DESCRIPTION
This PR replaces CartInstall with GodMode9's dump page on the guide, as GodMode9 has completely superseded CartInstall's usefulness.

Similar idea to this Kurisu PR: https://github.com/nh-server/Kurisu/pull/983 